### PR TITLE
Add projectile, tree-sitter entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 /recentf
 /saveplace
 /custom.el
+/projectile-bookmarks.eld
+/tree-sitter


### PR DESCRIPTION
Ignore the file `projectile-bookmarks.eld` and the directory `tree-sitter`. These are generated automatically by Emacs and user/installation-specific.