### PR TITLE
Remove duplicated command in eglot config in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,6 @@ To configure `eglot`, add the following to `~/.emacs.d/post-init.el`:
   :ensure nil
   :defer t
   :commands (eglot
-             eglot-rename
              eglot-ensure
              eglot-rename
              eglot-format-buffer))


### PR DESCRIPTION
The command `eglot-rename` appeared twice in the `:commands` section. Remove a duplicate.