### PR TITLE
Remove duplicated `pixel-scroll-precision-mode` line in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,6 @@ And [add the elpaca bootstrap code](https://github.com/progfolio/elpaca?tab=read
 (show-paren-mode +1)  ; Paren match highlighting
 (winner-mode 1)
 (delete-selection-mode 1)  ; Replace selected text with typed text
-(pixel-scroll-precision-mode 1)
 
 ;; Configure Emacs to ask for confirmation before exiting
 (setq confirm-kill-emacs 'y-or-n-p)


### PR DESCRIPTION
The `pixel-scroll-precision-mode` has been enabled in line 665. This PR removes the duplicated config.