### PR TITLE
README: remove duplicate `delete-selection-mode` line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1404,9 +1404,6 @@ fc-list : family | sed 's/,/\n/g' | sort -u
 ;; closing windows.
 (add-hook 'after-init-hook #'winner-mode)
 
-;; Replace selected text with typed text
-;; (delete-selection-mode 1)
-
 (use-package uniquify
   :ensure nil
   :custom


### PR DESCRIPTION
`delete-selection-mode` is already in that example. at the start:

https://github.com/jamescherti/minimal-emacs.d/blob/93bf23c18b98ac0aac443f9eb7f54d98b00b9f13/README.md?plain=1#L1359-L1361