### PR TITLE
chore: Replace consult.el's obsolete variables by public ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,8 +619,8 @@ Add the following to `~/.emacs.d/post-init.el` to set up Vertico, Consult, and E
    consult-theme :preview-key '(:debounce 0.2 any)
    consult-ripgrep consult-git-grep consult-grep
    consult-bookmark consult-recent-file consult-xref
-   consult--source-bookmark consult--source-file-register
-   consult--source-recent-file consult--source-project-recent-file
+   consult-source-bookmark consult-source-file-register
+   consult-source-recent-file consult-source-project-recent-file
    ;; :preview-key "M-."
    :preview-key '(:debounce 0.4 any))
   (setq consult-narrow-key "<"))


### PR DESCRIPTION
Just a minor change needed for your README recommendation to configure Vertico, consult & embark:

On January 12, 2026, minad removed some obsolete variables from consult.el, some of which were mentionned in minimal-emacs' README; cf. commit 3a8ac46916c0699f0905ac4fe65d72768add3efb: 
https://github.com/minad/consult/commit/3a8ac46916c0699f0905ac4fe65d72768add3efb

From minad's Changelog for `consult.el`:
> Remove obsolete =consult--source-*= variables. Use the public variables =consult-source-*= instead.